### PR TITLE
Updating dependencies to work with Isis 1.7.0-SNAPSHOT

### DIFF
--- a/extension/applib/pom.xml
+++ b/extension/applib/pom.xml
@@ -21,7 +21,7 @@ language governing permissions and limitations under the License.
 	<parent>
         <groupId>com.danhaywood.isis.wicket</groupId>
         <artifactId>danhaywood-isis-wicket-gmap3</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>danhaywood-isis-wicket-gmap3-applib</artifactId>

--- a/extension/pom.xml
+++ b/extension/pom.xml
@@ -26,7 +26,7 @@ language governing permissions and limitations under the License.
 
     <groupId>com.danhaywood.isis.wicket</groupId>
     <artifactId>danhaywood-isis-wicket-gmap3</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Isis Wicket Viewer Gmap3 Extension</name>
@@ -57,8 +57,8 @@ language governing permissions and limitations under the License.
     </developers>
 
     <properties>
-        <isis.version>1.4.0</isis.version>
-        <isis-viewer-wicket.version>1.4.0</isis-viewer-wicket.version>
+        <isis.version>1.7.0-SNAPSHOT</isis.version>
+        <isis-viewer-wicket.version>1.7.0-SNAPSHOT</isis-viewer-wicket.version>
 
         <wicketstuff-gmap3.version>6.13.0</wicketstuff-gmap3.version>
         <wicket.version>6.13.0</wicket.version>
@@ -203,17 +203,17 @@ language governing permissions and limitations under the License.
             <dependency>
                 <groupId>com.danhaywood.isis.wicket</groupId>
                 <artifactId>danhaywood-isis-wicket-gmap3-applib</artifactId>
-                <version>1.4.1-SNAPSHOT</version>
+                <version>1.4.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.danhaywood.isis.wicket</groupId>
                 <artifactId>danhaywood-isis-wicket-gmap3-service</artifactId>
-                <version>1.4.1-SNAPSHOT</version>
+                <version>1.4.2-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.danhaywood.isis.wicket</groupId>
                 <artifactId>danhaywood-isis-wicket-gmap3-ui</artifactId>
-                <version>1.4.1-SNAPSHOT</version>
+                <version>1.4.2-SNAPSHOT</version>
             </dependency>
 
             <dependency>
@@ -226,7 +226,7 @@ language governing permissions and limitations under the License.
             <dependency>
                 <!-- ASL v2.0 -->
                 <groupId>org.apache.isis.viewer</groupId>
-                <artifactId>isis-viewer-wicket-ui</artifactId>
+                <artifactId>isis-viewer-wicket</artifactId>
                 <version>${isis-viewer-wicket.version}</version>
             </dependency>
 

--- a/extension/service/pom.xml
+++ b/extension/service/pom.xml
@@ -21,7 +21,7 @@ language governing permissions and limitations under the License.
 	<parent>
         <groupId>com.danhaywood.isis.wicket</groupId>
         <artifactId>danhaywood-isis-wicket-gmap3</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>danhaywood-isis-wicket-gmap3-service</artifactId>

--- a/extension/ui/pom.xml
+++ b/extension/ui/pom.xml
@@ -21,7 +21,7 @@ language governing permissions and limitations under the License.
     <parent>
         <groupId>com.danhaywood.isis.wicket</groupId>
         <artifactId>danhaywood-isis-wicket-gmap3</artifactId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>danhaywood-isis-wicket-gmap3-ui</artifactId>
@@ -65,16 +65,17 @@ language governing permissions and limitations under the License.
             <artifactId>danhaywood-isis-wicket-gmap3-applib</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.isis.viewer</groupId>
-            <artifactId>isis-viewer-wicket-ui</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>org.wicketstuff</groupId>
             <artifactId>wicketstuff-gmap3</artifactId>
         </dependency>
 
+        <dependency>
+        	<groupId>org.apache.isis.viewer</groupId>
+        	<artifactId>isis-viewer-wicket-impl</artifactId>
+        	<version>${isis-viewer-wicket.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/zzzdemo/dom/pom.xml
+++ b/zzzdemo/dom/pom.xml
@@ -111,8 +111,8 @@
 		</dependency>
 
 		<dependency>
-            <groupId>org.apache.isis.objectstore</groupId>
-			<artifactId>isis-objectstore-jdo-applib</artifactId>
+            <groupId>org.apache.isis.core</groupId>
+			<artifactId>isis-core-objectstore-jdo-datanucleus</artifactId>
 		</dependency>
         
 		<dependency>
@@ -122,21 +122,25 @@
 		</dependency>
 
         <!-- Bytecode libraries (for mocking) -->
+<!--
         <dependency>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
             <scope>test</scope>
         </dependency>
+-->
         <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
             <scope>test</scope>
         </dependency>
+<!--
         <dependency>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
             <scope>test</scope>
         </dependency>
+-->
 
         <dependency>
             <groupId>com.danhaywood.isis.wicket</groupId>

--- a/zzzdemo/pom.xml
+++ b/zzzdemo/pom.xml
@@ -32,11 +32,12 @@
 	<properties>
 		<danhaywood-isis-wicket-gmap3.version>1.4.0</danhaywood-isis-wicket-gmap3.version>
 
-        <isis.version>1.4.0</isis.version>
-		<isis-objectstore-jdo.version>1.4.0</isis-objectstore-jdo.version>
-		<isis-viewer-wicket.version>1.4.0</isis-viewer-wicket.version>
-		<isis-viewer-restfulobjects.version>2.2.0</isis-viewer-restfulobjects.version>
-		<isis-security-shiro.version>1.4.0</isis-security-shiro.version>
+        <isis.version>1.7.0-SNAPSHOT</isis.version>
+		<isis-objectstore-jdo.version>1.7.0-SNAPSHOT</isis-objectstore-jdo.version>
+		<isis-viewer-wicket.version>1.7.0-SNAPSHOT</isis-viewer-wicket.version>
+		<isis-viewer-restfulobjects.version>1.7.0-SNAPSHOT</isis-viewer-restfulobjects.version>
+		<isis-security-shiro.version>1.7.0-SNAPSHOT</isis-security-shiro.version>
+		<isis-module-devutils.version>1.7.0-SNAPSHOT</isis-module-devutils.version>
 
         <!-- must be consistent with the versions defined by the JDO Objectstore -->
         <datanucleus-accessplatform-jdo-rdbms.version>3.3.6</datanucleus-accessplatform-jdo-rdbms.version>
@@ -286,8 +287,8 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.apache.isis.objectstore</groupId>
-				<artifactId>isis-objectstore-jdo</artifactId>
+				<groupId>org.apache.isis.core</groupId>
+				<artifactId>isis-core-objectstore-jdo-datanucleus</artifactId>
 				<version>${isis-objectstore-jdo.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
@@ -302,16 +303,16 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.apache.isis.viewer</groupId>
-				<artifactId>isis-viewer-restfulobjects</artifactId>
+				<groupId>org.apache.isis.core</groupId>
+				<artifactId>isis-core-viewer-restfulobjects-applib</artifactId>
 				<version>${isis-viewer-restfulobjects.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
 
 			<dependency>
-				<groupId>org.apache.isis.security</groupId>
-				<artifactId>isis-security-shiro</artifactId>
+				<groupId>org.apache.isis.core</groupId>
+				<artifactId>isis-core-security-shiro</artifactId>
 				<version>${isis-security-shiro.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
@@ -342,6 +343,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            
+	        <dependency>
+	        	<groupId>org.apache.isis.module</groupId>
+	        	<artifactId>isis-module-devutils-impl</artifactId>
+	        	<version>${isis-module-devutils.version}</version>
+	        </dependency>
 
         </dependencies>
     </dependencyManagement>

--- a/zzzdemo/webapp/pom.xml
+++ b/zzzdemo/webapp/pom.xml
@@ -175,20 +175,20 @@
         
         <!-- other isis components -->
         <dependency>
-            <groupId>org.apache.isis.objectstore</groupId>
-            <artifactId>isis-objectstore-jdo-datanucleus</artifactId>
+            <groupId>org.apache.isis.core</groupId>
+            <artifactId>isis-core-objectstore-jdo-datanucleus</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.isis.viewer</groupId>
             <artifactId>isis-viewer-wicket-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.isis.viewer</groupId>
-            <artifactId>isis-viewer-restfulobjects-server</artifactId>
+            <groupId>org.apache.isis.core</groupId>
+            <artifactId>isis-core-viewer-restfulobjects-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.isis.security</groupId>
-            <artifactId>isis-security-shiro</artifactId>
+            <groupId>org.apache.isis.core</groupId>
+            <artifactId>isis-core-security-shiro</artifactId>
         </dependency>
 
 
@@ -246,6 +246,10 @@
             <artifactId>danhaywood-isis-wicket-gmap3-ui</artifactId>
         </dependency>
 
+        <dependency>
+        	<groupId>org.apache.isis.module</groupId>
+        	<artifactId>isis-module-devutils-impl</artifactId>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Dan, an update that uses Isis 1.7.0-SNAPSHOT, in case you can use it.
